### PR TITLE
Make re-frame-10x work correctly

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -46,8 +46,9 @@
   bidi                       {:mvn/version "2.1.3"}
   kibu/pushy                 {:mvn/version "0.3.8"}
 
-  cljsjs/react-highlight {:mvn/version "1.0.7-1"}
+  cljsjs/react-highlight     {:mvn/version "1.0.7-1"}
   day8.re-frame/re-frame-10x {:mvn/version "0.3.0-2-react16"}
+  day8.re-frame/tracing      {:mvn/version "0.5.1"}
 
   day8.re-frame/test         {:mvn/version "0.1.5"}
   binaryage/devtools         {:mvn/version "0.9.9"}

--- a/deps.edn
+++ b/deps.edn
@@ -45,8 +45,10 @@
   cljs-ajax                  {:mvn/version "0.7.3"}
   bidi                       {:mvn/version "2.1.3"}
   kibu/pushy                 {:mvn/version "0.3.8"}
-  day8.re-frame/re-frame-10x {:mvn/version "0.3.0-1-react16"}
-  day8.re-frame/tracing      {:mvn/version "0.5.0"}
+
+  cljsjs/react-highlight {:mvn/version "1.0.7-1"}
+  day8.re-frame/re-frame-10x {:mvn/version "0.3.0-2-react16"}
+
   day8.re-frame/test         {:mvn/version "0.1.5"}
   binaryage/devtools         {:mvn/version "0.9.9"}
   cljsjs/react-dates         {:mvn/version "12.2.4-1"}

--- a/src/bridge/event/ui.cljs
+++ b/src/bridge/event/ui.cljs
@@ -6,7 +6,8 @@
             [bridge.ui.base :as ui.base]
             [bridge.ui.spec :as ui.spec]
             [bridge.ui.util :refer [<== ==>]]
-            [re-frame.core :as rf]))
+            [re-frame.core :as rf]
+            [day8.re-frame.tracing :refer-macros [fn-traced]]))
 
 (def routes
   {"/events" {""                     :list-events
@@ -35,7 +36,7 @@
 
 (rf/reg-event-fx ::save-new-event!
   [ui.spec/check-spec-interceptor]
-  (fn [db [_ chapter-id new-event]]
+  (fn-traced [db [_ chapter-id new-event]]
     {:dispatch
      (ui.ajax/action :bridge.event.api/save-new-event!
                      {:chapter-id chapter-id


### PR DESCRIPTION
This set of dependencies seems to work correctly. The next version of 10x will include the updated react-highlight dependency.